### PR TITLE
Code to generate tzinfo from Java taking into account historical offset changes

### DIFF
--- a/timezones/WriteTzInfo.java
+++ b/timezones/WriteTzInfo.java
@@ -1,4 +1,4 @@
-// Requires Java 17+
+// Requires Java 11+
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -10,6 +10,7 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import static java.time.ZoneOffset.UTC;
 import static java.util.TimeZone.getTimeZone;
@@ -53,7 +54,7 @@ public class WriteTzInfo {
                     .map(e -> generateAdjustmentLines(e.getKey(), e.getValue()))
                     .flatMap(Collection::stream)
                     .sorted()
-                    .toList();
+                    .collect(Collectors.toList());
 
             for (String line : lines) {
                 out.println(line);

--- a/timezones/WriteTzInfo.java
+++ b/timezones/WriteTzInfo.java
@@ -1,0 +1,66 @@
+// Requires Java 17+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+import java.util.function.Function;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static java.time.ZoneOffset.UTC;
+import static java.util.TimeZone.getTimeZone;
+import static java.util.stream.Collectors.toMap;
+
+public class WriteTzInfo {
+
+    private static final ZonedDateTime startDate = ZonedDateTime.of(1900, 1, 1, 0, 0, 0, 0, UTC);
+    private static final ZonedDateTime endDate = ZonedDateTime.of(2100, 1, 1, 0, 0, 0, 0, UTC);
+
+    private static List<String> generateAdjustmentLines(String zoneName, ZoneId zoneId) {
+        System.out.println(zoneName);
+        List<String> result = new ArrayList<>();
+        ZoneOffset previousOffset = null;
+        ZonedDateTime currentDate = startDate.withZoneSameInstant(zoneId);
+
+        // Repeatedly increment by 1-minute, checking if the offset changes, and recording when this happens
+        while (currentDate.isBefore(endDate)) {
+            if (!currentDate.getOffset().equals(previousOffset)) {
+                previousOffset = currentDate.getOffset();
+                String timeUtcString = currentDate.withZoneSameInstant(UTC).format(DateTimeFormatter.ofPattern("yyyy.MM.dd'D'HH:mm:ss.SSS"));
+                result.add(zoneName + "," + timeUtcString + "," + previousOffset.getTotalSeconds());
+            }
+            currentDate = currentDate.plusMinutes(1);
+        }
+
+        return result;
+    }
+
+    public static void main(String[] args) {
+        try (PrintWriter out = new PrintWriter(new FileWriter("tzinfo.csv"))) {
+            out.println("timezoneID,gmtDateTime,offset");
+
+            // Get all timezone ids by joining ZoneId (new) and TimeZone (legacy)
+            // ZoneId doesn't include three-letter codes such as EST, and will convert these to a format such as -05:00
+            // So we need to preserve the names that TimeZone uses
+            Map<String, ZoneId> zoneIds = ZoneId.getAvailableZoneIds().stream().collect(toMap(Function.identity(), ZoneId::of));
+            Arrays.stream(TimeZone.getAvailableIDs()).forEach(x -> zoneIds.merge(x, getTimeZone(x).toZoneId(), (zid, tz) -> zid));
+
+            List<String> lines = zoneIds.entrySet().parallelStream()
+                    .map(e -> generateAdjustmentLines(e.getKey(), e.getValue()))
+                    .flatMap(Collection::stream)
+                    .sorted()
+                    .toList();
+
+            for (String line : lines) {
+                out.println(line);
+            }
+
+        } catch (IOException ex) {
+            Logger.getLogger(WriteTzInfo.class.getName()).log(Level.SEVERE, null, ex);
+        }
+    }
+}


### PR DESCRIPTION
Considers the actual offset on a minute-by-minute basis, rather than just the daylight savings time.

This is important for timezone regions that change their underlying offset or which stop using daylight savings.

The code uses the union of the ZoneId and TimeZone classes to cover all timezone IDs.